### PR TITLE
Fix Conda and Docker release workflows

### DIFF
--- a/.github/workflows/conda_upload.yml
+++ b/.github/workflows/conda_upload.yml
@@ -51,20 +51,22 @@ jobs:
 
       - name: Build conda package
         id: build
-        shell: bash -l {0}
+        shell: bash -el {0}
         env:
           PKG_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           mkdir -p "$CONDA_BLD_DIR"
-          conda build .\
+          conda build . \
             -c mmariotti -c anaconda -c bioconda -c biobuilds \
             --no-anaconda-upload
-            PKG_PATH=$(conda build . --output)
-            echo "pkg=$PKG_PATH" >> "$GITHUB_OUTPUT" 
-            echo "Built package at: $PKG_PATH"
+          PKG_PATH=$(conda build . \
+            -c mmariotti -c anaconda -c bioconda -c biobuilds \
+            --output)
+          echo "pkg=$PKG_PATH" >> "$GITHUB_OUTPUT"
+          echo "Built package at: $PKG_PATH"
       
       - name: Upload to Anaconda
-        shell: bash -l {0}
+        shell: bash -el {0}
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,10 @@ RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/legacy.NOTSUPPORTED/2.2.
 RUN selenoprofiles -setup && \
     yes "" | selenoprofiles -download 
 
-# Accept Anaconda Terms of Service
-RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main && \
-    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+# Accept Anaconda Terms of Service when supported by this conda version.
+# Older/current container images may not provide the `conda tos` subcommand.
+RUN (conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main || true) && \
+    (conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r || true)
 
 RUN conda config --add channels defaults && \
     conda config --add channels bioconda && \


### PR DESCRIPTION
## Summary
Fix the manually triggered Conda and Docker release workflows after the 4.5.8 release.

## Diagnosis
- PyPI upload succeeded, so the package/version bump itself is not the common failure.
- Conda upload failed in `Build conda package` because `conda-build` was installed in the environment initialized by `setup-miniconda`, but the later build/upload steps used `shell: bash -l {0}`. That login shell did not preserve the activated setup-miniconda environment, so `conda build` was unavailable.
- Docker upload failed because the current `continuumio/miniconda3` image has `conda 26.3.2`, but no `conda tos` subcommand:
  `conda: error: argument COMMAND: invalid choice: 'tos'`.

## Changes
- Use `shell: bash -el {0}` for Conda build/upload steps, matching the already-working install step and setup-miniconda activation expectations.
- Keep channels consistent for `conda build . --output`.
- Make `conda tos accept` in the Dockerfile best-effort so images with and without that plugin/subcommand both work.

## Validation
- Parsed both workflow YAML files locally with Ruby YAML.
- Ran `git diff --check`.
- Confirmed current `continuumio/miniconda3` lacks `conda tos`, reproducing the Docker failure source.