### PR TITLE
Use base env for Conda upload workflow

### DIFF
--- a/.github/workflows/conda_upload.yml
+++ b/.github/workflows/conda_upload.yml
@@ -34,7 +34,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.12
-          auto-activate-base: true
+          activate-environment: base
+          auto-activate: true
           channels: mmariotti,anaconda,bioconda,biobuilds
           show-channel-urls: true
 


### PR DESCRIPTION
## Summary
Follow-up fix for the Conda upload workflow after PR #26.

## Diagnosis
The rerun after PR #26 still failed at `conda build`:

```text
shell: /usr/bin/bash -el {0}
conda: error: argument COMMAND: invalid choice: 'build'
```

The logs show why: `setup-miniconda@v3` defaulted to `activate-environment: test`, even though the workflow was trying to activate base via the deprecated `auto-activate-base: true` option. As a result:

- `conda-build` was installed into `/usr/share/miniconda/envs/test`
- the build step invoked `/usr/share/miniconda/condabin/conda build`
- that base/condabin `conda` did not have the `build` command/plugin available

The setup action emitted the relevant warning:

```text
`auto-activate-base` is deprecated. Please use `auto-activate`.
If your installer does not use the `base` environment as the default environment,
also add `activate-environment: base`.
```

## Change
Replace deprecated implicit base activation with explicit base activation:

```yaml
activate-environment: base
auto-activate: true
```

## Validation
- Parsed `.github/workflows/conda_upload.yml` with Ruby YAML.
- Ran `git diff --check`.
- Confirmed the new failure source from run `28133395004` logs.